### PR TITLE
Python 3.14 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14.0-rc.1"]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/make_it_sync/func_wrapper.py
+++ b/make_it_sync/func_wrapper.py
@@ -10,7 +10,7 @@ def _sync_version_of_function(fn: Callable[..., Awaitable[R]], *args, **kwargs) 
     # Determine what environment we are currently in.
     loop_exists = False
     try:
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         loop_exists = True
         loop_is_running = loop.is_running()
     except RuntimeError:

--- a/make_it_sync/func_wrapper.py
+++ b/make_it_sync/func_wrapper.py
@@ -3,16 +3,28 @@ from concurrent.futures import ThreadPoolExecutor
 from functools import wraps
 from typing import Callable, TypeVar, Awaitable
 
-R = TypeVar('R')
+R = TypeVar("R")
 
 
 def _sync_version_of_function(fn: Callable[..., Awaitable[R]], *args, **kwargs) -> R:
-    loop = asyncio.get_event_loop()
-    if not loop.is_running():
+    # Determine what environment we are currently in.
+    loop_exists = False
+    try:
+        loop = asyncio.get_event_loop()
+        loop_exists = True
+        loop_is_running = loop.is_running()
+    except RuntimeError:
+        loop_is_running = False
+
+    # Next, depending on the environment, we will either run the function directly
+    # or create a new thread to run it in.
+    if loop_exists and not loop_is_running:
         # Call the function directly
         r = fn(*args, **kwargs)
         return loop.run_until_complete(r)
     else:
+        # Forced to create a new event loop.
+
         def get_data_wrapper(*args, **kwargs):
             # New thread - get the loop.
             loop = asyncio.new_event_loop()
@@ -27,7 +39,7 @@ def _sync_version_of_function(fn: Callable[..., Awaitable[R]], *args, **kwargs) 
 
 
 def make_sync(fn: Callable[..., Awaitable[R]]) -> Callable[..., R]:
-    '''
+    """
     Wraps an async function to make it synchronous. The function will will try to run it
     on the current thread if it can fine an event loop that isn't running, otherwise it will
     create a new thread and execute it there - one thread per async method call - and block
@@ -43,7 +55,7 @@ def make_sync(fn: Callable[..., Awaitable[R]]) -> Callable[..., R]:
     Note:
       If you call this 10 times with long running async methods, they will run on 10 different
       threads.
-    '''
+    """
     # Define the function we will return that will do the work
     if _check_is_abstract(fn):
         func_name = fn.__name__
@@ -53,11 +65,14 @@ def make_sync(fn: Callable[..., Awaitable[R]]) -> Callable[..., R]:
             v = getattr(args[0], func_name, None)
             if v is None:
                 raise NotImplementedError(
-                    f'Function {func_name} is not implemented by {args[0].__name__}')
+                    f"Function {func_name} is not implemented by {args[0].__name__}"
+                )
             return _sync_version_of_function(v, *(args[1:]), **kwargs)
+
         del wrapped_call.__isabstractmethod__
         return wrapped_call
     else:
+
         @wraps(fn)
         def wrapped_call(*args, **kwargs):
             return _sync_version_of_function(fn, *args, **kwargs)
@@ -66,5 +81,5 @@ def make_sync(fn: Callable[..., Awaitable[R]]) -> Callable[..., R]:
 
 
 def _check_is_abstract(f: Callable):
-    'Check to see if the function is callable'
-    return hasattr(f, '__isabstractmethod__') and f.__isabstractmethod__
+    "Check to see if the function is callable"
+    return hasattr(f, "__isabstractmethod__") and f.__isabstractmethod__

--- a/make_it_sync/func_wrapper.py
+++ b/make_it_sync/func_wrapper.py
@@ -61,7 +61,7 @@ def make_sync(fn: Callable[..., Awaitable[R]]) -> Callable[..., R]:
         func_name = fn.__name__
 
         @wraps(fn)
-        def wrapped_call(*args, **kwargs):
+        def wrapped_call(*args, **kwargs):  # type: ignore
             v = getattr(args[0], func_name, None)
             if v is None:
                 raise NotImplementedError(
@@ -69,7 +69,7 @@ def make_sync(fn: Callable[..., Awaitable[R]]) -> Callable[..., R]:
                 )
             return _sync_version_of_function(v, *(args[1:]), **kwargs)
 
-        del wrapped_call.__isabstractmethod__
+        del wrapped_call.__isabstractmethod__  # type: ignore
         return wrapped_call
     else:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "make-it-sync"
 version = "1.0.0"
 description = "Create a sync version of an async function"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = "MIT"
 keywords = []
 authors = [{ name = "Gordon Watts", email = "gwatts@uw.edu" }]
@@ -18,13 +18,12 @@ classifiers = [
   "Topic :: Software Development",
   "Topic :: Utilities",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.7",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = []

--- a/tests/test_func_wrapper.py
+++ b/tests/test_func_wrapper.py
@@ -1,4 +1,4 @@
-from asyncio import new_event_loop, set_event_loop, get_running_loop, sleep
+from asyncio import new_event_loop, set_event_loop, sleep
 import inspect
 from typing import Tuple
 from abc import ABC, abstractmethod


### PR DESCRIPTION
The very well used `get_running_loop` has been decpreciated for a while, and is now gone. Remove using it!

Fixes #6